### PR TITLE
Add project-wide .gitignore file for .NET, Flutter, and IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,35 +1,75 @@
-# Miscellaneous
-*.class
-*.lock
-*.log
-*.pyc
-*.swp
-.buildlog/
-.history
+##################################
+#         .NET SECTION           #
+##################################
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+[Ww][Ii][Nn]32/
+[Aa][Rr][Mm]/
+[Aa][Rr][Mm]64/
+bld/
+[Bb]in/
+[Oo]bj/
+[Ll]og/
+[Ll]ogs/
+
+# .NET Core
+project.lock.json
+project.fragment.lock.json
+artifacts/
+
+# ASP.NET Scaffolding
+ScaffoldingReadMe.txt
+
+# NuGet Packages
+*.nupkg
+*.snupkg
+**/[Pp]ackages/*
+!**/[Pp]ackages/build/
+
+# MSBuild Binary and Structured Log
+*.binlog
+
+# MSTest test Results
+[Tt]est[Rr]esult*/
+[Bb]uild[Ll]og.*
+
+# NUnit
+*.VisualState.xml
+TestResult.xml
+nunit-*.xml
+
+# Code Coverage Results
+*.coverage
+*.coveragexml
+TestResults/
+
+# Configuration and Environment files
+*.env
+*.env.local
+appsettings.*.local.json
+appsettings.local.json
+
+# Entity Framework
+*.edmx.diagram
+*.edmx.sql
+
+# Local database files
+*.db
+*.db-shm
+*.db-wal
+*.sqlite
+*.sqlite3
 
 
-
-# Flutter repo-specific
-/bin/cache/
-/bin/internal/bootstrap.bat
-/bin/internal/bootstrap.sh
-/bin/mingit/
-/dev/benchmarks/mega_gallery/
-/dev/bots/.recipe_deps
-/dev/bots/android_tools/
-/dev/devicelab/ABresults*.json
-/dev/docs/doc/
-/dev/docs/flutter.docs.zip
-/dev/docs/lib/
-/dev/docs/pubspec.yaml
-/dev/integration_tests/**/xcuserdata
-/dev/integration_tests/**/Pods
-/packages/flutter/coverage/
-version
-analysis_benchmark.json
-
-# packages file containing multi-root paths
-.packages.generated
+##################################
+#        FLUTTER SECTION         #
+##################################
 
 # Flutter/Dart/Pub related
 **/doc/api/
@@ -41,21 +81,23 @@ analysis_benchmark.json
 .pub-preload-cache/
 .pub/
 build/
+
+# Flutter build outputs
 flutter_*.png
 linked_*.ds
 unlinked.ds
 unlinked_spec.ds
 
 # Android related
+*.jks
 **/android/**/gradle-wrapper.jar
-.gradle/
+**/android/**/GeneratedPluginRegistrant.java
 **/android/captures/
 **/android/gradlew
 **/android/gradlew.bat
-**/android/local.properties
-**/android/**/GeneratedPluginRegistrant.java
 **/android/key.properties
-*.jks
+**/android/local.properties
+.gradle/
 
 # iOS/XCode related
 **/ios/**/*.mode1v3
@@ -63,36 +105,24 @@ unlinked_spec.ds
 **/ios/**/*.moved-aside
 **/ios/**/*.pbxuser
 **/ios/**/*.perspectivev3
-**/ios/**/*sync/
-**/ios/**/.sconsign.dblite
-**/ios/**/.tags*
-**/ios/**/.vagrant/
 **/ios/**/DerivedData/
-**/ios/**/Icon?
 **/ios/**/Pods/
 **/ios/**/.symlinks/
-**/ios/**/profile
 **/ios/**/xcuserdata
 **/ios/.generated/
 **/ios/Flutter/.last_build_id
 **/ios/Flutter/App.framework
 **/ios/Flutter/Flutter.framework
-**/ios/Flutter/Flutter.podspec
 **/ios/Flutter/Generated.xcconfig
 **/ios/Flutter/ephemeral
-**/ios/Flutter/app.flx
-**/ios/Flutter/app.zip
 **/ios/Flutter/flutter_assets/
 **/ios/Flutter/flutter_export_environment.sh
-**/ios/ServiceDefinitions.json
 **/ios/Runner/GeneratedPluginRegistrant.*
 
 # macOS
 **/Flutter/ephemeral/
-**/Pods/
 **/macos/Flutter/GeneratedPluginRegistrant.swift
 **/macos/Flutter/ephemeral
-**/xcuserdata/
 
 # Windows
 **/windows/flutter/generated_plugin_registrant.cc
@@ -104,16 +134,132 @@ unlinked_spec.ds
 **/linux/flutter/generated_plugin_registrant.h
 **/linux/flutter/generated_plugins.cmake
 
+# Web (important for cross-platform)
+**/web/flutter_service_worker.js
+**/web/manifest.json
+
 # Coverage
-coverage/
+lcov.info
 
-# Symbols
-app.*.symbols
-
-# Exceptions to above rules.
+# Exceptions to above rules
 !**/ios/**/default.mode1v3
 !**/ios/**/default.mode2v3
 !**/ios/**/default.pbxuser
 !**/ios/**/default.perspectivev3
-!/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
-!/dev/ci/**/Gemfile.lock
+
+
+##################################
+#      DOCKER & DEPLOYMENT       #
+##################################
+
+# Docker override files for local development
+docker-compose.override.yml
+docker-compose.local.yml
+
+# Kubernetes local configs
+*.local.yaml
+*.local.yml
+
+# Local deployment scripts
+deploy.local.*
+
+
+##################################
+#       SECURITY & SECRETS       #
+##################################
+
+# API Keys and secrets
+*.key
+*.pem
+*.pfx
+appsecrets.json
+secrets/
+secrets.json
+
+# AI service configuration files
+anthropic.local.json
+azure-ai.local.json
+openai.local.json
+
+
+##################################
+#     COVERAGE & TEST OUTPUT     #
+##################################
+
+# Coverage reports and test results
+coverage/
+lcov.info
+*.coverage
+*.coveragexml
+TestResults/
+
+
+##################################
+#     COMMON OUTPUT FOLDERS      #
+##################################
+
+# General build and temporary output
+dist/
+out/
+.temp/
+.tmp/
+temp/
+tmp/
+.cache/
+
+# Package manager caches
+node_modules/
+.npm/
+.yarn/
+
+# Application logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+
+
+##################################
+#         GLOBAL IGNORE          #
+##################################
+
+# Operating System files
+.DS_Store          # macOS
+Thumbs.db          # Windows
+*~                 # Linux/Unix backup files
+
+# Editor temporary files
+*.swp
+*.swo
+*.tmp
+*.bak
+*.backup
+
+# Personal notes (allow keeping local notes)
+TODO.personal.*
+NOTES.personal.*
+
+
+##################################
+#          IDE SECTION           #
+##################################
+
+# VS Code
+.vscode/
+!.vscode/extensions.json
+!.vscode/settings.json
+
+# Visual Studio
+.vs/
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# JetBrains IDEs
+.idea/
+*.DotSettings.user
+*.iml
+
+# Xcode
+*.xcworkspace
+*.xcuserstate


### PR DESCRIPTION
### Summary

This PR introduces a comprehensive `.gitignore` covering:

- .NET build outputs, NuGet artifacts, test results, and EF files
- Flutter platform-specific and tool-specific directories
- Secrets, local databases, coverage reports, and logs
- IDE-specific files (VS Code, Visual Studio, JetBrains, Xcode, etc.)
- Docker/K8s local deployment configs
- General OS and editor temp files

### Why?

- Keeps the repo clean and avoids accidental commits of build artifacts, secrets, or environment-specific files
- Supports multiple tech stacks (Flutter + .NET) and development environments

Ready for future changes to be tracked cleanly.

Closes #1